### PR TITLE
Fix HCArgumentCaptor captured value copy

### DIFF
--- a/Source/Library/Object/HCArgumentCaptor.m
+++ b/Source/Library/Object/HCArgumentCaptor.m
@@ -36,7 +36,7 @@
     {
         id value = item ?: [NSNull null];
         if ([value conformsToProtocol:@protocol(NSCopying)])
-            value = [value copy];
+            value = [value copyWithZone:nil];
         [self.values addObject:value];
     }
 }


### PR DESCRIPTION
Conforming to `NSCopying` doesn't guarantee that an object responds to `copy`. This code can still crash when the captured value is a mock of a protocol.